### PR TITLE
Missing translation "Useful links" in french

### DIFF
--- a/templates/frontOffice/default/I18n/fr_FR.php
+++ b/templates/frontOffice/default/I18n/fr_FR.php
@@ -225,6 +225,7 @@ return array(
     'Update Profile' => 'Mettre à jour votre profil',
     'Update Quantity' => 'Mettre à jour la quantité',
     'Upsell Products' => 'Produits liés',
+    'Useful links' => 'Liens utiles',
     'View' => 'Voir',
     'View Cart' => 'Voir le panier',
     'View all' => ' Voir tout',


### PR DESCRIPTION
Updated fr_FR.php with missing "Useful links" translation.